### PR TITLE
Feature/Change-the-age-brackets-cut-off-of-OTZ-from-10-24-to-10-19-in-the-DWH-logic

### DIFF
--- a/Scripts/REPORTING/load_aggregate_otz.sql
+++ b/Scripts/REPORTING/load_aggregate_otz.sql
@@ -42,7 +42,7 @@ INNER JOIN NDWH.dbo.DimPatient pat on pat.PatientKey = otz.PatientKey
 INNER JOIN NDWH.dbo.DimPartner p on p.PartnerKey = otz.PartnerKey
 LEFT JOIN NDWH.dbo.FactViralLoads vl on vl.PatientKey = otz.PatientKey and vl.PatientKey IS NOT NULL
 LEFT JOIN NDWH.dbo.DimDate as date on date.DateKey = otz.OTZEnrollmentDateKey
-WHERE age.Age BETWEEN 10 AND 24 AND IsTXCurr = 1
+WHERE age.Age BETWEEN 10 AND 19 AND IsTXCurr = 1
 GROUP BY 
 	MFLCode, 
 	f.FacilityName, 

--- a/Scripts/REPORTING/load_aggregate_otz_eligibility_and_enrollments.sql
+++ b/Scripts/REPORTING/load_aggregate_otz_eligibility_and_enrollments.sql
@@ -1,39 +1,63 @@
-IF OBJECT_ID(N'REPORTING.[dbo].[AggregateOTZOutcome]', N'U') IS NOT NULL 	
-	drop  TABLE REPORTING.[dbo].[AggregateOTZOutcome]
+IF OBJECT_ID(N'[REPORTING].[dbo].[AggregateOTZEligibilityAndEnrollments]', N'U')IS NOT NULL 	
+	DROP TABLE [REPORTING].[dbo].[AggregateOTZEligibilityAndEnrollments]
 GO
-
 SELECT DISTINCT
-    MFLCode,
-    f.FacilityName,
-    County,
-    SubCounty,
-    p.PartnerName,
-    a.AgencyName,
-    Gender,
-    age.DATIMAgeGroup as AgeGroup,
-    CONVERT(char(7), cast(cast(OTZEnrollmentDateKey as char) as datetime), 23) as OTZEnrollmentYearMonth,
-    EOMONTH(date.Date) as AsofDate,
-    TransitionAttritionReason as Outcome,
-    COUNT(TransitionAttritionReason) as patients_totalOutcome,
-    CAST(GETDATE() AS DATE) AS LoadDate 
-INTO REPORTING.dbo.AggregateOTZOutcome
-FROM NDWH.dbo.FactOTZ otz
-INNER join NDWH.dbo.DimAgeGroup age on age.AgeGroupKey=otz.AgeGroupKey
-INNER join NDWH.dbo.DimFacility f on f.FacilityKey = otz.FacilityKey
-INNER JOIN NDWH.dbo.DimAgency a on a.AgencyKey = otz.AgencyKey
-INNER JOIN NDWH.dbo.DimPatient pat on pat.PatientKey = otz.PatientKey
-INNER JOIN NDWH.dbo.DimPartner p on p.PartnerKey = otz.PartnerKey
+	MFLCode,
+	f.FacilityName,
+	County,
+	SubCounty,
+	p.PartnerName,
+	a.AgencyName,
+	Gender,
+	age.DATIMAgeGroup AS AgeGroup,
+	CONVERT (CHAR (7), CAST (CAST (OTZEnrollmentDateKey AS CHAR)AS datetime), 23)AS OTZEnrollmentYearMonth,
+	SUM (CASE WHEN otz.ModulesPreviouslyCovered IS NOT NULL THEN 1 ELSE 0 END)AS CompletedTraining,
+	TransferInStatus,
+	ModulesPreviouslyCovered,
+	SUM (ModulesCompletedToday_OTZ_Orientation) AS CompletedToday_OTZ_Orientation,
+	SUM (ModulesCompletedToday_OTZ_Participation) AS CompletedToday_OTZ_Participation,
+	SUM (ModulesCompletedToday_OTZ_Leadership)AS CompletedToday_OTZ_Leadership,
+	SUM (ModulesCompletedToday_OTZ_MakingDecisions) AS CompletedToday_OTZ_MakingDecisions,
+	SUM (ModulesCompletedToday_OTZ_Transition) AS CompletedToday_OTZ_Transition,
+	SUM (ModulesCompletedToday_OTZ_TreatmentLiteracy) AS CompletedToday_OTZ_TreatmentLiteracy,
+	SUM (ModulesCompletedToday_OTZ_SRH) AS CompletedToday_OTZ_SRH,
+	SUM (ModulesCompletedToday_OTZ_Beyond) AS CompletedToday_OTZ_Beyond,
+	FirstVL,
+	LastVL,
+	ValidVLResult,
+	vl.ValidVLResultCategory2 as ValidVLResultCategory,
+	EOMONTH(date.Date)as AsofDate,
+	SUM (vl.EligibleVL)AS EligibleVL,
+	SUM (vl.HasValidVL)AS HasValidVL,
+	COUNT (*)patients_eligible,
+	COUNT(otz.PatientKey)as Enrolled,
+	CAST(GETDATE()AS DATE)AS LoadDate
+INTO [REPORTING].[dbo].[AggregateOTZEligibilityAndEnrollments]
+FROM NDWH.dbo.FACTART art
+INNER JOIN NDWH.dbo.DimAgeGroup age ON age.AgeGroupKey= art.AgeGroupKey
+INNER JOIN NDWH.dbo.DimFacility f ON f.FacilityKey = art.FacilityKey
+INNER JOIN NDWH.dbo.DimAgency a ON a.AgencyKey = art.AgencyKey
+INNER JOIN NDWH.dbo.DimPatient pat ON pat.PatientKey = art.PatientKey
+INNER JOIN NDWH.dbo.DimPartner p ON p.PartnerKey = art.PartnerKey
+LEFT JOIN NDWH.dbo.FactViralLoads vl ON vl.PatientKey = art.PatientKey AND vl.PatientKey IS NOT NULL 
+FULL OUTER JOIN NDWH.dbo.FactOTZ otz on otz.PatientKey = art.PatientKey
 LEFT JOIN NDWH.dbo.DimDate as date on date.DateKey = otz.OTZEnrollmentDateKey
-WHERE TransitionAttritionReason is not null AND IsTXCurr = 1
-GROUP BY
-    MFLCode, 
-    f.FacilityName, 
-    County, SubCounty, 
-    p.PartnerName, 
-    a.AgencyName, 
-    Gender, 
-    age.DATIMAgeGroup, 
-    CONVERT(char(7), cast(cast(OTZEnrollmentDateKey as char) as datetime), 23), 
-    EOMONTH(date.Date),
-    TransitionAttritionReason
+WHERE age.Age BETWEEN 10 AND 19 AND IsTXCurr = 1 
+GROUP BY 
+	MFLCode,
+	f.FacilityName,
+	County,SubCounty,
+	p.PartnerName,
+	a.AgencyName,
+	Gender,
+	age.DATIMAgeGroup,
+	CONVERT (CHAR (7), CAST (CAST(OTZEnrollmentDateKey AS CHAR)AS datetime), 23),
+	TransferInStatus,
+	ModulesPreviouslyCovered,
+	vl.FirstVL,
+	vl.LastVL,
+	vl.ValidVLResult,
+	ValidVLResultCategory2,
+	EOMONTH(date.Date)
 
+GO

--- a/Scripts/REPORTING/load_aggregate_otz_outcome.sql
+++ b/Scripts/REPORTING/load_aggregate_otz_outcome.sql
@@ -24,7 +24,7 @@ INNER JOIN NDWH.dbo.DimAgency a on a.AgencyKey = otz.AgencyKey
 INNER JOIN NDWH.dbo.DimPatient pat on pat.PatientKey = otz.PatientKey
 INNER JOIN NDWH.dbo.DimPartner p on p.PartnerKey = otz.PartnerKey
 LEFT JOIN NDWH.dbo.DimDate as date on date.DateKey = otz.OTZEnrollmentDateKey
-WHERE TransitionAttritionReason is not null AND IsTXCurr = 1
+WHERE TransitionAttritionReason is not null AND IsTXCurr = 1 AND age.Age BETWEEN 10 AND 19
 GROUP BY 
     MFLCode, 
     f.FacilityName, 

--- a/Scripts/REPORTING/load_linelist_otz.sql
+++ b/Scripts/REPORTING/load_linelist_otz.sql
@@ -45,5 +45,6 @@ INNER JOIN NDWH.dbo.DimPatient pat on pat.PatientKey = otz.PatientKey
 INNER JOIN NDWH.dbo.DimPartner p on p.PartnerKey = otz.PartnerKey
 LEFT JOIN NDWH.dbo.FactViralLoads vl on vl.PatientKey = otz.PatientKey and vl.PatientKey IS NOT NULL
 LEFT JOIN NDWH.dbo.FACTART art on art.PatientKey = otz.PatientKey
-WHERE age.Age BETWEEN 10 AND 24 AND IsTXCurr = 1
+WHERE age.Age BETWEEN 10 AND 19 AND IsTXCurr = 1
+
 GO

--- a/Scripts/REPORTING/load_linelist_otz_eligibility_and_enrollments.sql
+++ b/Scripts/REPORTING/load_linelist_otz_eligibility_and_enrollments.sql
@@ -13,7 +13,7 @@ SELECT DISTINCT
 	a.AgencyName,
 	pat.Gender,
 	age.DATIMAgeGroup as AgeGroup,
-	otz.OTZEnrollmentDateKey,
+	date.Date as OTZEnrollmentDate,
 	LastVisitDateKey,
 	TransitionAttritionReason,
 	TransferInStatus,
@@ -34,9 +34,7 @@ SELECT DISTINCT
 	ValidVLResultCategory1,
 	ValidVLResultCategory2,
 	HasValidVL,
-	COUNT(CASE
-	WHEN art.PatientKey is not null THEN 1
-	ELSE 0 END) as Eligible,
+	COUNT(CASE WHEN art.PatientKey is not null THEN 1 ELSE 0 END) as Eligible,
 	COUNT(CASE WHEN otz.PatientKey is not null THEN 1 ELSE NULL END) as Enrolled,
     CAST(GETDATE() AS DATE) AS LoadDate 
 INTO [REPORTING].[dbo].[LineListOTZEligibilityAndEnrollments]
@@ -48,7 +46,8 @@ INNER JOIN NDWH.dbo.DimPatient pat ON pat.PatientKey = art.PatientKey
 INNER JOIN NDWH.dbo.DimPartner p ON p.PartnerKey = art.PartnerKey
 LEFT JOIN NDWH.dbo.FactViralLoads vl ON vl.PatientKey = art.PatientKey AND vl.PatientKey IS NOT NULL 
 FULL OUTER JOIN NDWH.dbo.FactOTZ otz on otz.PatientKey = art.PatientKey
-WHERE age.Age BETWEEN 10 AND 24  AND IsTXCurr = 1
+LEFT JOIN NDWH.dbo.DimDate as date on date.DateKey = otz.OTZEnrollmentDateKey
+WHERE age.Age BETWEEN 10 AND 19  AND IsTXCurr = 1
 GROUP BY 
 	PatientPKHash, 
     PatientIDHash,
@@ -60,7 +59,7 @@ GROUP BY
 	a.AgencyName,
 	pat.Gender,
 	age.DATIMAgeGroup,
-	otz.OTZEnrollmentDateKey,
+	date.Date,
 	LastVisitDateKey,
 	TransitionAttritionReason,
 	TransferInStatus,


### PR DESCRIPTION
Main change is to adapt OTZ age eligibility from 10 to 24 years to 10 to 19 years

Jira ticket: https://thepalladiumgroup.atlassian.net/browse/KHP3-4064