### PR TITLE
modified ODS and NDWH scripts

### DIFF
--- a/Scripts/NDWH/ALL DIMENSIONS/load_DimHTSTraceOutcome.sql
+++ b/Scripts/NDWH/ALL DIMENSIONS/load_DimHTSTraceOutcome.sql
@@ -7,7 +7,7 @@ MERGE [NDWH].[dbo].[DimHTSTraceOutcome] AS a
 
 					SELECT DISTINCT TraceOutcome 
 					FROM ODS.dbo.HTS_PartnerTracings
-					WHERE  TraceOutcome <> 'null' AND TraceOutcome <> ''AND TracingOutcome IS NOT NULL
+					WHERE  TraceOutcome <> 'null' AND TraceOutcome <> ''AND TraceOutcome IS NOT NULL
 				) AS b 
 						ON(
 							a.[TraceOutcome] = b.[TraceOutcome]

--- a/Scripts/ODS/CT_DOCKET/Load_CT_AllergiesChronicIllness.sql
+++ b/Scripts/ODS/CT_DOCKET/Load_CT_AllergiesChronicIllness.sql
@@ -91,7 +91,7 @@ BEGIN
 							a.[Date_Created]		=b.[Date_Created],
 							a.[Date_Last_Modified]	=b.[Date_Last_Modified],
 							a.RecordUUID			=b.RecordUUID,
-							a.voided		=b.voided
+							a.voided		=b.voided,
 							a.Controlled    = b.Controlled;
 												
 					

--- a/Scripts/ODS/CT_DOCKET/Load_CT_PatientBaselines.sql
+++ b/Scripts/ODS/CT_DOCKET/Load_CT_PatientBaselines.sql
@@ -43,13 +43,13 @@ BEGIN
 									INNER JOIN [DWAPICentral].[dbo].[Facility] F WITH(NoLock)  ON P.[FacilityId] = F.Id AND F.Voided=0
 								GROUP BY F.code,p.[PatientPID],InnerPB.voided
 							) tm 
-							ON f.code = tm.[SiteCode] and p.PatientPID=tm.PatientPK and PB.voided=tm.PatientPK and  PB.created = tm.Maxdatecreated
+							ON f.code = tm.[SiteCode] and p.PatientPID=tm.PatientPK and PB.voided=tm.voided and  PB.created = tm.Maxdatecreated
 		WHERE p.gender!='Unknown' AND F.code >0) b
 
 		ON a.patientPK = b.PatientPK  
 		and a.sitecode = b.sitecode 
 		and a.voided   = b.voided
-		--and a.ID =b. ID
+		and a.ID =b. ID
 
 
 		WHEN NOT MATCHED THEN 

--- a/Scripts/ODS/CT_DOCKET/Remove_CT_ODS_Duplicates/CT_PatientBaselines.sql
+++ b/Scripts/ODS/CT_DOCKET/Remove_CT_ODS_Duplicates/CT_PatientBaselines.sql
@@ -1,9 +1,9 @@
 with cte AS (
 				Select
 				PatientPK,
-				sitecode,id,
+				sitecode,
 
-				 ROW_NUMBER() OVER (PARTITION BY PatientPK,sitecode,id ORDER BY
+				 ROW_NUMBER() OVER (PARTITION BY PatientPK,sitecode ORDER BY
 				PatientPK,sitecode) Row_Num
 				FROM [ODS].[DBO].CT_PatientBaselines(NoLock)
 				)

--- a/Scripts/ODS/HTS_DOCKET/Load_HTS_PartnerNotificationServices.sql
+++ b/Scripts/ODS/HTS_DOCKET/Load_HTS_PartnerNotificationServices.sql
@@ -61,7 +61,7 @@ BEGIN
 				a.[Gender]							=b.[Gender],
 				a.[CurrentlyLivingWithIndexClient]	=b.[CurrentlyLivingWithIndexClient],	
 				a.[LinkDateLinkedToCare]			=b.[LinkDateLinkedToCare],
-				a.RecordUUID                         = b.RecordUUID
+				a.RecordUUID                         = b.RecordUUID,
 				a.IndexPatientPk                     = b.IndexPatientPk;
 
 				

--- a/Scripts/ODS/Mhealth/Load_Ushauri_Patient.sql
+++ b/Scripts/ODS/Mhealth/Load_Ushauri_Patient.sql
@@ -72,5 +72,18 @@ BEGIN
 						a.[Date_Modified]					=	b.[Date_Modified],
 						a.[PKV]							=	b.[PKV],
 						a.[NUPI]							=	b.[NUPI] ;
+
+		with cte AS (
+						Select
+						Sitecode,
+						UshauriPatientPK,
+						
+						 ROW_NUMBER() OVER (PARTITION BY UshauriPatientPK,Sitecode ORDER BY
+						UshauriPatientPK) Row_Num
+						FROM [ODS].[dbo].[Ushauri_Patient](NoLock)
+						)
+						delete from cte 
+						Where Row_Num >1 ;
+
 		
 	END

--- a/Scripts/ODS/PrEP DOCKET/Load_PrEP_Patient.sql
+++ b/Scripts/ODS/PrEP DOCKET/Load_PrEP_Patient.sql
@@ -86,7 +86,19 @@ MERGE [ODS].[dbo].[PrEP_Patient] AS a
 					a.DateStartedPrEPattransferringfacility=b.DateStartedPrEPattransferringfacility,
 					a.ClientPreviouslyonPrep=b.ClientPreviouslyonPrep,
 					a.PrevPrepReg=b.PrevPrepReg,
-					a.RecordUUID = b.RecordUUID;										
+					a.RecordUUID = b.RecordUUID;
+
+			with cte AS (
+				Select
+				PatientPK,
+				sitecode,
+
+				 ROW_NUMBER() OVER (PARTITION BY PatientPK,sitecode ORDER BY
+				PatientPK,sitecode) Row_Num
+				FROM [ODS].[dbo].[PrEP_Patient](NoLock)
+				)
+			delete   from cte 
+				Where Row_Num >1;										
 
 	END
 

--- a/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patients.sql
+++ b/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patients.sql
@@ -102,25 +102,8 @@ UPDATE [ODS].[DBO].[CT_Patient] SET Inschool = CASE
             END
 			where Inschool in ('New', 'New client','Re-enroll','Transfer in','Transfer-In','Transit','')
 Go
--------------------Update PopulationType-------------------------------------------------------------
-UPDATE [ODS].[DBO].[CT_Patient] SET PopulationType = CASE
-                WHEN  PopulationType in ('General Population', 'General Population','GeneralPopulation') THEN  ' General Population'
-				WHEN PopulationType in  ('FSW','Female Having Sex With Female',' Key Population','Key population') THEN ' Key Population'			
-            END
-			where PopulationType in ('General Population', 'General Population','GeneralPopulation','FSW','Female Having Sex With Female',' Key Population','Key population','')
-Go
-UPDATE [ODS].[DBO].[CT_Patient] SET KeyPopulationType = CASE
-                WHEN  KeyPopulationType in ('MSM', 'MSW') THEN  'MSM'
-				WHEN KeyPopulationType ='FSW' THEN 'FSW'
-				WHEN KeyPopulationType='PWID' THEN 'PWID'
-				WHEN KeyPopulationType='Transgender' THEN 'Transgender'	
-            END
-			where KeyPopulationType in ('MSM','MSW','FSW','PWID','N/A','Transgender','')
-GO
+
 -------------------Update PatientResidentCounty-------------------------------------------------------------
-Go
-UPDATE   [ODS].[DBO].[CT_Patient]  SET  [ODS].[DBO].[CT_Patient].PatientResidentCounty=NULL
-Go 
 
 ---------------------------------UpdatePatientSource--------------------------------------------------
 UPDATE M  SET  M.PatientSource= T.target_name  

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_ARTPatients.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_ARTPatients.sql
@@ -1,0 +1,7 @@
+update ARTP
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_ARTPatients   ARTP
+		JOIN ODS.dbo.CT_Patient p
+	on ARTP.SiteCode = p.SiteCode and ARTP.PatientPK = p.PatientPK
+	WHERE ARTP.PatientPKHash IS NULL OR ARTP.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_AdverseEvents.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_AdverseEvents.sql
@@ -1,0 +1,7 @@
+update AE 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_AdverseEvents   AE 
+		JOIN ODS.dbo.CT_Patient p
+	on AE .SiteCode = p.SiteCode and AE.PatientPK = p.PatientPK
+	WHERE AE.PatientPKHash IS NULL OR AE.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_AllergiesChronicIllness.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_AllergiesChronicIllness.sql
@@ -1,0 +1,7 @@
+update AC
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_AllergiesChronicIllness  AC
+		JOIN ODS.dbo.CT_Patient p
+	on AC.SiteCode = p.SiteCode and AC.PatientPK = p.PatientPK
+	WHERE AC.PatientPKHash IS NULL OR AC.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_ArtFastTrack.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_ArtFastTrack.sql
@@ -1,0 +1,7 @@
+update ArtFastTrack
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from [ODS].[dbo].[CT_ArtFastTrack]  ArtFastTrack
+		JOIN ODS.dbo.CT_Patient p
+	on ArtFastTrack.SiteCode = p.SiteCode and ArtFastTrack.PatientPK = p.PatientPK
+	WHERE ArtFastTrack.PatientPKHash IS NULL OR ArtFastTrack.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_CancerScreening.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_CancerScreening.sql
@@ -1,0 +1,8 @@
+
+		update CS
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from [ODS].[dbo].[CT_CancerScreening]  CS
+		JOIN ODS.dbo.CT_Patient p
+	on CS.SiteCode = p.SiteCode and CS.PatientPK = p.PatientPK
+	WHERE CS.PatientPKHash IS NULL OR CS.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_CervicalCancerScreening.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_CervicalCancerScreening.sql
@@ -1,0 +1,7 @@
+update ccs 
+		set PatientPKHash = p.PatientPKHash,
+			ccs.PatientIDHash = p.PatientIDHash
+	from [ODS].[dbo].[CT_CervicalCancerScreening]   ccs 
+		JOIN ODS.dbo.CT_Patient p
+		on ccs .SiteCode = p.SiteCode and ccs .PatientPK = p.PatientPK
+		WHERE ccs.PatientPKHash IS NULL OR ccs.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_ContactListing.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_ContactListing.sql
@@ -1,0 +1,7 @@
+update CL
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_ContactListing    CL
+		JOIN ODS.dbo.CT_Patient p
+	on CL.SiteCode = p.SiteCode and CL.PatientPK = p.PatientPK
+	WHERE CL.PatientPKHash IS NULL OR CL.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Covid.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Covid.sql
@@ -1,0 +1,7 @@
+update C 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_Covid   C
+		JOIN ODS.dbo.CT_Patient p
+	on C.SiteCode = p.SiteCode and C.PatientPK = p.PatientPK
+	WHERE C.PatientPKHash IS NULL OR C.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_DefaulterTracing.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_DefaulterTracing.sql
@@ -1,0 +1,7 @@
+update DT 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_DefaulterTracing      DT 
+		JOIN ODS.dbo.CT_Patient p
+	on DT .SiteCode = p.SiteCode and DT.PatientPK = p.PatientPK
+	WHERE DT.PatientPKHash IS NULL OR DT.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_DepressionScreening.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_DepressionScreening.sql
@@ -1,0 +1,7 @@
+update DS 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_DepressionScreening    DS 
+		JOIN ODS.dbo.CT_Patient p
+	on DS .SiteCode = p.SiteCode and DS.PatientPK = p.PatientPK
+	WHERE DS.PatientPKHash IS NULL OR DS.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_DrugAlcoholScreening.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_DrugAlcoholScreening.sql
@@ -1,0 +1,7 @@
+update DAS 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_DrugAlcoholScreening   DAS 
+		JOIN ODS.dbo.CT_Patient p
+	on DAS.SiteCode = p.SiteCode and DAS.PatientPK = p.PatientPK
+	WHERE DAS.PatientPKHash IS NULL OR DAS.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_EnhancedAdherenceCounselling.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_EnhancedAdherenceCounselling.sql
@@ -1,0 +1,7 @@
+update EAC
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_EnhancedAdherenceCounselling     EAC
+		JOIN ODS.dbo.CT_Patient p
+	on EAC.SiteCode = p.SiteCode and EAC.PatientPK = p.PatientPK
+	WHERE EAC.PatientPKHash IS NULL OR EAC.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_GbvScreening.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_GbvScreening.sql
@@ -1,0 +1,7 @@
+update GbvS 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_GbvScreening  GbvS
+		JOIN ODS.dbo.CT_Patient p
+	on GbvS.SiteCode = p.SiteCode and GbvS.PatientPK = p.PatientPK
+	WHERE GbvS.PatientPKHash IS NULL OR GbvS.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_IITRiskScores.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_IITRiskScores.sql
@@ -1,0 +1,7 @@
+update IIT 
+	set PatientPKHash = p.PatientPKHash,
+		IIT.PatientIDHash = p.PatientIDHash
+	from [ODS].[dbo].[CT_IITRiskScores]   IIT 
+	JOIN ODS.dbo.CT_Patient p
+	on IIT .SiteCode = p.SiteCode and IIT .PatientPK = p.PatientPK
+	WHERE IIT.PatientPKHash IS NULL OR IIT.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Ipt.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Ipt.sql
@@ -1,0 +1,7 @@
+update Ipt
+		set PatientPKHash = p.PatientPKHash,
+			Ipt.PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_Ipt  Ipt
+	JOIN ODS.dbo.CT_Patient p
+		on Ipt.SiteCode = p.SiteCode and Ipt.PatientPK = p.PatientPK
+	WHERE Ipt.PatientPKHash IS NULL OR Ipt.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Otz.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Otz.sql
@@ -1,0 +1,7 @@
+update Otz 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_Otz     Otz 
+		JOIN ODS.dbo.CT_Patient p
+	on Otz .SiteCode = p.SiteCode and Otz.PatientPK = p.PatientPK
+	WHERE Otz.PatientPKHash IS NULL OR Otz.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Ovc.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Ovc.sql
@@ -1,0 +1,7 @@
+update Ovc 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_Ovc     Ovc 
+		JOIN ODS.dbo.CT_Patient p
+	on Ovc .SiteCode = p.SiteCode and Ovc.PatientPK = p.PatientPK
+	WHERE Ovc.PatientPKHash IS NULL OR Ovc.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Ovc_CPIMSUniqueIdentifier.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Ovc_CPIMSUniqueIdentifier.sql
@@ -1,0 +1,4 @@
+	update Ovc
+		set CPIMSUniqueIdentifierHash = convert(nvarchar(64), hashbytes('SHA2_256', cast(Ovc.CPIMSUniqueIdentifier  as nvarchar(36))), 2)
+	from [ODS].[dbo].[CT_Ovc]  Ovc		
+	WHERE Ovc.CPIMSUniqueIdentifierHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Patient.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Patient.sql
@@ -1,0 +1,5 @@
+	update ODS.dbo.CT_Patient 
+		set PatientPKHash = convert(nvarchar(64), hashbytes('SHA2_256', cast(PatientPk  as nvarchar(36))), 2),
+			PatientIDHash = convert(nvarchar(64), hashbytes('SHA2_256', cast(PatientID  as nvarchar(36))), 2)
+	FROM ODS.dbo.CT_Patient
+	WHERE PatientPKHash IS NULL OR PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientBaselines.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientBaselines.sql
@@ -1,0 +1,7 @@
+update PB
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_PatientBaselines  PB
+		JOIN ODS.dbo.CT_Patient p
+	on PB.SiteCode = p.SiteCode and PB.PatientPK = p.PatientPK
+	WHERE PB.PatientPKHash IS NULL OR PB.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientLabs.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientLabs.sql
@@ -1,0 +1,7 @@
+update Labs 
+		set PatientPKHash = p.PatientPKHash,
+			Labs.PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_PatientLabs   Labs 
+		JOIN ODS.dbo.CT_Patient p
+		on Labs .SiteCode = p.SiteCode and Labs .PatientPK = p.PatientPK
+		WHERE Labs.PatientPKHash IS NULL OR Labs.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientPharmacy.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientPharmacy.sql
@@ -1,0 +1,7 @@
+update Phar 
+		set PatientPKHash = p.PatientPKHash,
+		    Phar.PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_PatientPharmacy   Phar
+	JOIN ODS.dbo.CT_Patient p
+	on Phar .SiteCode = p.SiteCode and Phar .PatientPK = p.PatientPK
+	WHERE Phar.PatientPKHash IS NULL OR Phar.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientStatus.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientStatus.sql
@@ -1,0 +1,7 @@
+update PS 
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from  ODS.dbo.CT_PatientStatus   PS 
+		JOIN ODS.dbo.CT_Patient p
+	on PS .SiteCode = p.SiteCode and PS.PatientPK = p.PatientPK
+	WHERE PS.PatientPKHash IS NULL OR PS.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientVisits.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_PatientVisits.sql
@@ -1,0 +1,7 @@
+update v
+		set PatientPKHash = p.PatientPKHash,
+			V.PatientIDHash = p.PatientIDHash
+	from ODS.dbo.CT_PatientVisits  v
+	JOIN ODS.dbo.CT_Patient p
+		on v.SiteCode = p.SiteCode and v.PatientPK = p.PatientPK
+		WHERE V.PatientPKHash IS NULL OR V.PatientIDHash IS NULL;

--- a/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Relationships.sql
+++ b/Scripts/ODS/utils/COLUMN_HASHING/CT/HASH_PATIENTPK_PATIENTID/Update_CT_Relationships.sql
@@ -1,0 +1,7 @@
+update Rlshp
+		set PatientPKHash = p.PatientPKHash,
+			PatientIDHash = p.PatientIDHash
+	from [ODS].[dbo].[CT_Relationships]  Rlshp
+		JOIN ODS.dbo.CT_Patient p
+	on Rlshp.SiteCode = p.SiteCode and Rlshp.PatientPK = p.PatientPK
+	WHERE Rlshp.PatientPKHash IS NULL OR Rlshp.PatientIDHash IS NULL;


### PR DESCRIPTION
1. load_DimHTSTraceOutcome under NDWH was modified to remove the syntax error on the referenced columns on the where
2. Load_CT_AllergiesChronicIllness added a comma on the update under the merge
3. Load_CT_PatientBaselines , uncommented the ID bit on the merge due to the duplicate issue.
4. CT_PatientBaselines, Included only the sitecode and patientPK as the unique identifiers to remove duplicates
5. Load_HTS_PartnerNotificationServices, added a comma on the update under the merge. Deal with synxtax error.
6. Load_Ushauri_Patient, Included the CTE to remove duplicates.
7. Load_PrEP_Patient ,Included the CTE to remove duplicates.
8. clean_CT_patients, removed the update  to a) PopulationType, b)KeyPopulationType as the column was defaulted to null) , c) PatientResidentCounty as to allow the reporting of data as is from the source.
9. Seperated the hashing on C&T scripts to individual scripts. This will allow the calling of the scripts seperately in ssis hence reducing the time of refresh. I will be retiring Update_PatientPKHash_PatientIDHash.