### PR TITLE
Returning deleted column isCT

### DIFF
--- a/Scripts/REPORTING/load_all_emr_sites.sql
+++ b/Scripts/REPORTING/load_all_emr_sites.sql
@@ -11,6 +11,7 @@ WITH ModulesUptake AS (
         isEMRSite,
         PartnerName,
         AgencyName,
+        isCT,
         modules.isHTS,
         isHTSML,
         isIITML,


### PR DESCRIPTION
Noticed that column isCT was removed in a previous commit thus causing breaks in the portal, This commit returns that deleted column