### PR TITLE
Added an update on the CT_patientStatus to clean the ExitDate and Exi…

### DIFF
--- a/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patient_status.sql
+++ b/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patient_status.sql
@@ -41,4 +41,16 @@ WHERE Project IN ('Ampathplus', 'AMPATH', 'UCSF Clinical Kisumu', 'CHAP Uzima', 
 
 GO
 
+---Clean ExitDate, ExitReason
+UPDATE [ODS].[DBO].[CT_PatientStatus]
+    SET ExitDate = NULL,ExitReason=NULL
+WHERE ReEnrollmentDate > ExitDate
+GO
+
+---Clean DeathDate incase ExitDate has been cleaned
+UPDATE [ODS].[DBO].[CT_PatientStatus]
+    SET DeathDate = NULL
+WHERE ExitDate is null
+GO
+
 

--- a/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patient_status.sql
+++ b/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patient_status.sql
@@ -45,6 +45,7 @@ GO
 UPDATE [ODS].[DBO].[CT_PatientStatus]
     SET ExitDate = NULL,ExitReason=NULL
 WHERE ReEnrollmentDate > ExitDate
+and ExitReason in ('dead','Death','Died')
 GO
 
 ---Clean DeathDate incase ExitDate has been cleaned


### PR DESCRIPTION
…treason where ReEnrollmentDate is greater that the exitDate. Meaning, if a patient has died and later ReEnrolled, we assume that the earlier entry was erronious hence default the exitdate and exitreason to null.EMR do the same according to Chege