### PR TITLE
Added a cleaning update to nullify 'nupi not found' on the ct_patient

### DIFF
--- a/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patients.sql
+++ b/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patients.sql
@@ -4,7 +4,7 @@
 ------Update Date of Birth to missing where Year <1910------------------------------
 
 ------Update Date of Birth to missing where Year <1910------------------------------
-UPDATE ODS.[Care].CT_Patient   SET DOB = NULL where (DOB) < CAST ('1910-01-01' AS DATE)
+UPDATE [ODS].[Care].[CT_Patient]   SET DOB = NULL where (DOB) < CAST ('1910-01-01' AS DATE)
 Go
 
 UPDATE [ODS].[Care].[CT_Patient]  SET DOB = NULL where (DOB) > GETDATE()
@@ -148,7 +148,7 @@ WHERE Nupi='';
 
 update a
 set NUPI = null
-from ODS.Care.CT_Patient a
+from [ODS].[Care].[CT_Patient] a
 where NUPI like '%Client not found.%'
 
 

--- a/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patients.sql
+++ b/Scripts/ODS/data_quality/CT_cleaning_scripts/clean_CT_patients.sql
@@ -146,4 +146,9 @@ UPDATE a
     from [ODS].[Care].[CT_Patient] a
 WHERE Nupi='';
 
+update a
+set NUPI = null
+from ODS.Care.CT_Patient a
+where NUPI like '%Client not found.%'
+
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Address the issue of 'nupi not found' by setting NUPI to null for entries where NUPI contains 'Client not found.'.