### PR TITLE
moved the ODS.Dim.All_EMRSites to ODS.Care.All_EMRSites

### DIFF
--- a/Scripts/NDWH/C&T FACT TABLES/load_FactLatestObs.sql
+++ b/Scripts/NDWH/C&T FACT TABLES/load_FactLatestObs.sql
@@ -2,7 +2,7 @@
 IF OBJECT_ID(N'[NDWH].[Fact].[FactLatestObs]', N'U') IS NOT NULL 
 	DROP TABLE [NDWH].[Fact].[FactLatestObs];
 
-ALTER TABLE ODS.Dim.All_EMRSites  ALTER COLUMN SDP_Agency nvarchar(4000) ;
+ALTER TABLE ODS.Care.All_EMRSites  ALTER COLUMN SDP_Agency nvarchar(4000) ;
 
 BEGIN	
 with MFL_partner_agency_combination as (


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Move the All_EMRSites table from the ODS.Dim schema to the ODS.Care schema.