### PR TITLE
Bugfix/Correcting-the-reference-to-DB-for-IIT-Risk-Scores

### DIFF
--- a/Scripts/REPORTING/HIVCaseSurveillance/load_cs_aggregate_iit_risk_scores.sql
+++ b/Scripts/REPORTING/HIVCaseSurveillance/load_cs_aggregate_iit_risk_scores.sql
@@ -1,5 +1,5 @@
-IF OBJECT_ID(N'[REPORTING].[dbo].[CSAggregateIITRiskScores]', N'U') IS NOT NULL 			
-	DROP TABLE [REPORTING].[dbo].[CSAggregateIITRiskScores]
+IF OBJECT_ID(N'[HIVCaseSurveillance].[dbo].[CSAggregateIITRiskScores]', N'U') IS NOT NULL 			
+	DROP TABLE [HIVCaseSurveillance].[dbo].[CSAggregateIITRiskScores]
 GO
 
 BEGIN


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the reference to the database schema for the `CSAggregateIITRiskScores` table from `REPORTING` to `HIVCaseSurveillance`.