### PR TITLE
Th MERGE statement attempted to UPDATE or DELETE the same row more th…

### DIFF
--- a/Scripts/ODS/HTS_DOCKET/Load_HTS_PartnerTracings.sql
+++ b/Scripts/ODS/HTS_DOCKET/Load_HTS_PartnerTracings.sql
@@ -1,7 +1,6 @@
-
 BEGIN
 		MERGE [ODS].[HTS].[HTS_PartnerTracings] AS a
-			USING(SELECT DISTINCT  a.[FacilityName]
+			USING(SELECT DISTINCT a.ID,a.[FacilityName]
 			  ,a.[SiteCode]
 			  ,a.[PatientPk]
 			  ,a.[HtsNumber]
@@ -12,25 +11,26 @@ BEGIN
 			  ,a.[TraceOutcome]
 			  ,a.[BookingDate] 
 			  ,a.RecordUUID
-			  	 
+		
 		  FROM [HTSCentral].[dbo].[HtsPartnerTracings](NoLock) a
 		  inner join (select tn.[SiteCode],tn.[PatientPk],tn.[HtsNumber],tn.[TraceType],tn.[TraceDate],tn.BookingDate,tn.[TraceOutcome],
-		  max(ID) As MaxID,max(cast(DateExtracted as date))MaxDateExtracted from [HTSCentral].[dbo].[HtsPartnerTracings](NoLock) tn
+		  max(ID) As MaxID,
+		  max(cast(DateExtracted as date))MaxDateExtracted from [HTSCentral].[dbo].[HtsPartnerTracings](NoLock) tn
 		               group by tn.[SiteCode],tn.[PatientPk],tn.[HtsNumber],tn.[TraceType],tn.BookingDate,tn.[TraceDate],tn.[TraceOutcome]
 					)tm
 			on a.[SiteCode] =tm.[SiteCode] and a.[PatientPk] =tm.[PatientPk] and a.[TraceType] = tm.[TraceType] and a.BookingDate =tm.BookingDate and cast(a.DateExtracted as date) = MaxDateExtracted
 	       and a.ID = tm.MaxID
 		INNER JOIN [HTSCentral].[dbo].Clients (NoLock) Cl
-		  on a.PatientPk = Cl.PatientPk and a.SiteCode = Cl.SiteCode
+		  on a.PatientPk = Cl.PatientPk and a.SiteCode = Cl.SiteCode		  
 		  ) AS b 
 			ON(
 				a.PatientPK  = b.PatientPK 
-			and a.SiteCode = b.SiteCode
-			and a.TraceDate  = b.TraceDate 			
-			and a.BookingDate  = b.BookingDate 
-			and a.[TraceOutcome] = b.[TraceOutcome]
-			and a.[TraceType] = b.[TraceType]
-			and a.RecordUUID  = b.RecordUUID
+				and a.SiteCode = b.SiteCode
+				and a.TraceDate  = b.TraceDate 			
+				and a.[TraceOutcome] = b.[TraceOutcome]
+				and a.[TraceType] = b.[TraceType]
+				and a.RecordUUID  = b.RecordUUID
+				and a.ID   = b.ID
 
 			)
 	WHEN NOT MATCHED THEN 
@@ -39,8 +39,7 @@ BEGIN
 
 	WHEN MATCHED THEN
 		UPDATE SET 
-			a.[FacilityName]=b.[FacilityName],
-			
+			a.[FacilityName]=b.[FacilityName],			
 			a.[TraceType]	=b.[TraceType],
 			a.[TraceDate]	=b.[TraceDate],
 			a.[TraceOutcome]=b.[TraceOutcome],
@@ -49,4 +48,6 @@ BEGIN
 
 		
 END
+
+
 


### PR DESCRIPTION
…an once. This happens when a target row matches more than one source row. A MERGE statement cannot UPDATE/DELETE the same row of the target table multiple times. Refine the ON clause to ensure a target row matches at most one source row, or use the GROUP BY clause to group the source records